### PR TITLE
Improve styles for mylkguys!

### DIFF
--- a/src/js/components/day.jsx
+++ b/src/js/components/day.jsx
@@ -39,9 +39,8 @@ export default class Day extends React.Component {
 
     return (
       <span className = "tsc-day__title">
-        {renderTitle(momentTime)}
-        <br/>
-        {renderDay(momentTime)}
+        <span>{renderTitle(momentTime)}</span>
+        <span>{renderDay(momentTime)}</span>
       </span>
     );
   }

--- a/src/js/components/day.jsx
+++ b/src/js/components/day.jsx
@@ -33,13 +33,16 @@ export default class Day extends React.Component {
   _renderTitle() {
     const {
       renderTitle,
+      renderDay,
       momentTime,
     } = this.props;
 
     return (
-      <div className = "tsc-day__title">
-        <span>{renderTitle(momentTime)}</span>
-      </div>
+      <span className = "tsc-day__title">
+        {renderTitle(momentTime)}
+        <br/>
+        {renderDay(momentTime)}
+      </span>
     );
   }
 
@@ -120,7 +123,10 @@ Day.defaultProps = {
   timeslotFormat: DEFAULT_TIMESLOT_FORMAT,
   timeslotShowFormat: DEFAULT_TIMESLOT_SHOW_FORMAT,
   renderTitle: (momentTime) => {
-    return momentTime.format('dddd (D)');
+    return momentTime.format('dddd');
+  },
+  renderDay: (momentTime) => {
+    return momentTime.format('(D)');
   },
 };
 
@@ -144,6 +150,7 @@ Day.propTypes = {
   timeslotFormat: PropTypes.string.isRequired,
   timeslotShowFormat: PropTypes.string.isRequired,
   onTimeslotClick: PropTypes.func.isRequired,
+  renderDay: PropTypes.func.isRequired,
   renderTitle: PropTypes.func.isRequired,
   momentTime: PropTypes.object.isRequired,
   initialDate: PropTypes.object.isRequired,

--- a/src/styles/abstract/_variables.scss
+++ b/src/styles/abstract/_variables.scss
@@ -13,7 +13,7 @@ $timeslot-default-color: $color-main-black;
 $timeslot-selected-color: $color-white;
 $timeslot-disabled-color: #C6C3BD;
 $timeslot-border-radius: 0.25em;
-$timeslot-margin: 0.8em;
+$timeslot-margin: 0.5em;
 $timeslot-fonts: 'Open Sans', sans-serif;
 
 /**

--- a/src/styles/components/_day.scss
+++ b/src/styles/components/_day.scss
@@ -7,8 +7,23 @@
 .tsc-day__title {
   color: $day-default-color;
   font-family: $day-fonts;
-  text-align: center;
   font-weight: 700;
   padding: $timeslot-margin;
   text-transform: uppercase;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  > span:first-child {
+    margin-right: 0;
+  }
+}
+
+@media only screen and (max-width: 767px) {
+  .tsc-day__title {
+    flex-direction: row;
+    > span:first-child {
+      margin-right: 1ch;
+    }
+  }
 }

--- a/src/styles/components/_day.scss
+++ b/src/styles/components/_day.scss
@@ -9,6 +9,6 @@
   font-family: $day-fonts;
   text-align: center;
   font-weight: 700;
-  padding: 1em;
+  padding: $timeslot-margin;
   text-transform: uppercase;
 }

--- a/src/styles/components/_timeslot.scss
+++ b/src/styles/components/_timeslot.scss
@@ -5,7 +5,6 @@
 
 .tsc-timeslot {
   display: flex;
-  flex: 1;
   justify-content: center;
   padding: 1em;
   font-size: 0.9em;


### PR DESCRIPTION
This improve a bit the styles, given that the width for the calendar is not so big, we would like the words to break always so they are arranged evenly. Also while having different day schedules, we would like them not to be stretched, that is why we remove the `flex: 1` property.

- Avoid expanded times slots
- Always break the day string and day number.