### PR TITLE
Improve calendar

### DIFF
--- a/src/js/components/calendar.jsx
+++ b/src/js/components/calendar.jsx
@@ -62,7 +62,7 @@ export default class Calendar extends React.Component {
       initialDate,
     } = this.props;
 
-    const cal = new CalendarJS(currentDate.year(), currentDate.month() + 1);
+    const cal = new CalendarJS(currentDate.year(), currentDate.month() + 1, currentDate.day());
     const weeks = cal.generate();
 
     return (

--- a/src/js/components/calendar.jsx
+++ b/src/js/components/calendar.jsx
@@ -14,7 +14,7 @@ export default class Calendar extends React.Component {
     this._updateRenderDays(this.props.renderDays);
 
     this.state = {
-      currentDate: moment(props.initialDate),
+      currentDate: moment(),
       selectedTimeslots: [],
     };
   }

--- a/src/js/components/calendar.jsx
+++ b/src/js/components/calendar.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
-import CalendarJS from 'calendarjs';
 import Month from './month.jsx';
+import CalendarJS from '../util/calendarjs';
 
 export default class Calendar extends React.Component {
   constructor(props) {

--- a/src/js/demo/app.jsx
+++ b/src/js/demo/app.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import moment from 'moment';
 
 import '../../styles/demo/main.scss';
 
@@ -12,9 +11,6 @@ import customTimeslotSnippet from './snippets/custom-timeslot.md';
 export default class App extends React.Component {
   constructor(props) {
     super(props);
-
-    this.initialDate = moment([2017, 3, 24]);
-
   }
   render() {
     return (
@@ -31,7 +27,6 @@ export default class App extends React.Component {
         <h3> Using Custom Timeslots and Callback </h3>
         <MarkdownSnippet snippet = { customTimeslotSnippet }/>
         <ReactTimeslotCalendar
-          initialDate = { this.initialDate.format() }
           timeslots = { [
             ['9', '10'],
             ['10', '11'],

--- a/src/js/react-timeslot-calendar.jsx
+++ b/src/js/react-timeslot-calendar.jsx
@@ -23,7 +23,6 @@ ReactTimeslotCalendar.defaultProps = {
   timeslots: DEFAULT_TIMESLOTS,
 };
 
-
 /**
  * @type {String} initialDate:  The initial date in which to place the calendar. Must be MomentJS parseable.
  * @type {Array} timeslots:  An array of timeslots to be displayed in each day.
@@ -37,7 +36,6 @@ ReactTimeslotCalendar.defaultProps = {
  * @type {Object} onSelectTimeslot: Function which takes as parameters 1) The array of selected timeslots and 2) The latest selected timeslot.
  */
 ReactTimeslotCalendar.propTypes = {
-  initialDate: PropTypes.string.isRequired,
   timeslots: PropTypes.array.isRequired,
   timeslotProps: PropTypes.object,
   selectedTimeslots: PropTypes.array,

--- a/src/js/util/calendarjs.js
+++ b/src/js/util/calendarjs.js
@@ -1,0 +1,116 @@
+var moment = require('moment');
+
+var Calendar = (function() {
+
+  function Calendar(year, month) {
+    this.moment = moment();
+
+    if (year) {
+      this.moment.year(year);
+    }
+
+    if (month) {
+      if ('number' === typeof month) {
+        month--; // to offset moment cause moment "0" = Jan.
+      }
+      this.moment.month(month);
+    }
+
+    // set to the beginning of the month;
+    this.moment.date(1);
+  }
+
+  Calendar.prototype.daysOfWeekStrings = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+  Calendar.prototype.monthStrings = ['Jan', 'Feb', 'Apr', 'Mar', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+  Calendar.prototype.createDay = function(moment) {
+    return {
+      month: moment.month() + 1, // [0, 11]
+      date: moment.date(),
+      day: moment.day(),
+      year: moment.year(),
+      dayOfYear: moment.dayOfYear(),
+    };
+  };
+
+  Calendar.prototype.generate = function(opts) {
+    var m; // reused variable for moment()
+    var w; // reused variable as a "week"
+
+    // defaults
+    opts = opts || {};
+    if (opts.withOtherMonthDays === undefined) {
+      opts.withOtherMonthDays = true;
+    }
+
+    if (opts.withStaticLength === undefined) {
+      opts.withStaticLength = false;
+    }
+
+    // we will fill in this array
+    var weeks = [];
+
+    w = [];
+    m = moment(this.moment);
+    var daysInMonth = this.moment.daysInMonth();
+    var d = 1;
+    while (d <= daysInMonth) {
+      // finish and close off the week
+      if (m.day() === 0 && w.length) {
+        weeks.push(w);
+        w = [];
+      }
+
+      // add the day to the week
+      w.push(this.createDay(m));
+
+      // advance one day
+      m.add(1, 'days');
+      d++;
+    }
+
+    // add the last week
+    if (w.length) {
+      weeks.push(w);
+    }
+
+    // we will associate other days to the first
+    // and last weeks if applicable.
+    if (opts.withOtherMonthDays) {
+      w = weeks[0];
+      m = moment(this.moment).subtract(1, 'days');
+      while (w.length < 7) {
+        w.unshift(this.createDay(m));
+        m.subtract(1, 'days');
+      }
+      weeks[0] = w;
+
+      w = weeks[weeks.length-1];
+      m = moment(this.moment).add(1, 'months');
+      while (w.length < 7) {
+        w.push(this.createDay(m));
+        m.add(1, 'day');
+      }
+      weeks[weeks.length - 1] = w;
+
+      // if 5 weeks have been constructed, add one more
+      // to keep consistency with other months with 6
+      // weeks constructed
+      if (weeks.length === 5 && opts.withStaticLength) {
+        w = [];
+        while (w.length < 7) {
+          w.push(this.createDay(m));
+          m.add(1, 'day');
+        }
+        weeks.push(w);
+      }
+    }
+
+    return weeks;
+  };
+
+  return Calendar;
+
+})();
+
+module.exports = Calendar;

--- a/src/js/util/calendarjs.js
+++ b/src/js/util/calendarjs.js
@@ -1,8 +1,10 @@
+// eslint-disable-file
+// src: https://github.com/sjlu/calendarjs/blob/master/index.js
 var moment = require('moment');
 
 var Calendar = (function() {
 
-  function Calendar(year, month) {
+  function Calendar(year, month, date) {
     this.moment = moment();
 
     if (year) {
@@ -18,6 +20,7 @@ var Calendar = (function() {
 
     // set to the beginning of the month;
     this.moment.date(1);
+    this.date = date;
   }
 
   Calendar.prototype.daysOfWeekStrings = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
@@ -56,7 +59,7 @@ var Calendar = (function() {
     var d = 1;
     while (d <= daysInMonth) {
       // finish and close off the week
-      if (m.day() === 0 && w.length) {
+      if (m.day() === this.date && w.length) {
         weeks.push(w);
         w = [];
       }


### PR DESCRIPTION
Instead of using CalendarJS, I got the util file and modified it so we could send the initial day of the week and it will return the following weeks based on that. It seem too much of a hassle creating another fork of CalendarJS just for this, but let me know if you would prefer that.

Also because we want the calendar to start from today always, I forced it to start from today always, this could be changed of course.